### PR TITLE
feat: add Ansible collection for FluxNode provisioning

### DIFF
--- a/ansible_collection/runonflux/arcane_mage/README.md
+++ b/ansible_collection/runonflux/arcane_mage/README.md
@@ -1,0 +1,108 @@
+# Ansible Collection: runonflux.arcane_mage
+
+Ansible collection for provisioning ArcaneOS FluxNodes on Proxmox hypervisors using the [arcane-mage](https://github.com/RunOnFlux/arcane-mage) library.
+
+## Requirements
+
+- Python >= 3.13 on the Ansible controller
+- `arcane-mage >= 2.0.0` (`pip install arcane-mage`)
+- Proxmox VE >= 8.4.1
+- Proxmox API token with appropriate permissions
+
+## Installation
+
+### From source (development)
+
+```bash
+cd arcane-mage/ansible_collection/runonflux/arcane_mage
+ansible-galaxy collection build
+ansible-galaxy collection install runonflux-arcane_mage-*.tar.gz
+```
+
+### Using collections path
+
+Add the path to your `ansible.cfg`:
+
+```ini
+[defaults]
+collections_path = /path/to/arcane-mage/ansible_collection
+```
+
+## Modules
+
+| Module | Description |
+|--------|-------------|
+| `runonflux.arcane_mage.provision` | Provision an ArcaneOS FluxNode VM (UEFI, TPM 2.0, config disk) |
+| `runonflux.arcane_mage.deprovision` | Stop and delete a FluxNode VM |
+| `runonflux.arcane_mage.status` | Check VM status on a Proxmox node |
+| `runonflux.arcane_mage.validate` | Pre-flight validation (API, storage, ISO, network) |
+| `runonflux.arcane_mage.iso_info` | Get latest ArcaneOS ISO version, optionally download it |
+
+All modules use `delegate_to: localhost` since they communicate with Proxmox via its REST API.
+
+## Quick Start
+
+```yaml
+- name: Provision FluxNodes
+  hosts: proxmox_hosts
+  gather_facts: no
+  tasks:
+    - name: Get latest ISO
+      runonflux.arcane_mage.iso_info:
+      delegate_to: localhost
+      register: iso
+      run_once: true
+
+    - name: Download ISO to host
+      runonflux.arcane_mage.iso_info:
+        api_url: "https://{{ ansible_host }}:8006"
+        api_token: "{{ proxmox_token }}"
+        node: "{{ inventory_hostname | lower }}"
+        download: true
+      delegate_to: localhost
+
+    - name: Validate host is ready
+      runonflux.arcane_mage.validate:
+        api_url: "https://{{ ansible_host }}:8006"
+        api_token: "{{ proxmox_token }}"
+        node: "{{ inventory_hostname | lower }}"
+        network: vmbr4000
+        iso_name: "{{ iso.iso_name }}"
+      delegate_to: localhost
+
+    - name: Provision FluxNode
+      runonflux.arcane_mage.provision:
+        api_url: "https://{{ ansible_host }}:8006"
+        api_token: "{{ proxmox_token }}"
+        node: "{{ inventory_hostname | lower }}"
+        vm_name: "{{ inventory_hostname | lower }}-vs{{ idx + 1 }}"
+        node_tier: stratus
+        network: vmbr4000
+        iso_name: "{{ iso.iso_name }}"
+        hostname: "{{ inventory_hostname | lower }}-vs{{ idx + 1 }}"
+        console_password: "{{ console_password }}"
+        flux_id: "{{ flux_id }}"
+        identity_key: "{{ identity_key }}"
+        tx_id: "{{ tx_id }}"
+        output_id: "{{ output_id }}"
+        ip_allocation: static
+        ip_address: "{{ item }}/27"
+        gateway: "49.12.156.225"
+        start: true
+      delegate_to: localhost
+      loop: "{{ vswitch_vm_ips }}"
+      loop_control:
+        index_var: idx
+```
+
+## Node Tiers
+
+| Tier | Cores | RAM | Disk |
+|------|-------|-----|------|
+| cumulus | 4 | 8 GB | 220 GB |
+| nimbus | 8 | 32 GB | 440 GB |
+| stratus | 16 | 64 GB | 880 GB |
+
+## License
+
+MIT

--- a/ansible_collection/runonflux/arcane_mage/galaxy.yml
+++ b/ansible_collection/runonflux/arcane_mage/galaxy.yml
@@ -1,0 +1,21 @@
+namespace: runonflux
+name: arcane_mage
+version: 1.0.0
+readme: README.md
+authors:
+  - RunOnFlux <info@runonflux.io>
+description: Ansible collection for provisioning ArcaneOS FluxNodes on Proxmox via arcane-mage
+license_file: ../../../LICENSE
+tags:
+  - proxmox
+  - fluxnode
+  - arcaneos
+  - provisioning
+  - automation
+repository: https://github.com/RunOnFlux/arcane-mage
+documentation: https://github.com/RunOnFlux/arcane-mage
+homepage: https://runonflux.com
+issues: https://github.com/RunOnFlux/arcane-mage/issues
+build_ignore:
+  - "*.pyc"
+  - __pycache__

--- a/ansible_collection/runonflux/arcane_mage/meta/runtime.yml
+++ b/ansible_collection/runonflux/arcane_mage/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: ">=2.14.0"

--- a/ansible_collection/runonflux/arcane_mage/plugins/modules/deprovision.py
+++ b/ansible_collection/runonflux/arcane_mage/plugins/modules/deprovision.py
@@ -1,0 +1,165 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, RunOnFlux
+# License: MIT
+
+DOCUMENTATION = r"""
+---
+module: deprovision
+short_description: Remove a FluxNode VM from Proxmox
+version_added: "1.0.0"
+description:
+  - Stops a running VM and deletes it along with all its disks.
+  - Idempotent — succeeds if the VM does not exist.
+  - Target VM by name or ID.
+options:
+  api_url:
+    description: Proxmox API URL.
+    required: true
+    type: str
+  api_token:
+    description: Proxmox API token in format C(user@realm!tokenname=tokenvalue).
+    required: true
+    type: str
+    no_log: true
+  verify_ssl:
+    description: Whether to verify SSL certificates.
+    type: bool
+    default: false
+  node:
+    description: Proxmox cluster node name.
+    required: true
+    type: str
+  vm_name:
+    description: Name of the VM to deprovision. Mutually exclusive with I(vm_id).
+    type: str
+  vm_id:
+    description: ID of the VM to deprovision. Mutually exclusive with I(vm_name).
+    type: int
+requirements:
+  - "python >= 3.13"
+  - "arcane-mage >= 2.0.0"
+author:
+  - RunOnFlux
+"""
+
+EXAMPLES = r"""
+- name: Remove a FluxNode VM by name
+  runonflux.arcane_mage.deprovision:
+    api_url: "https://65.109.86.37:8006"
+    api_token: "{{ proxmox_token }}"
+    node: tsa
+    vm_name: tsa-vs1
+  delegate_to: localhost
+
+- name: Remove a FluxNode VM by ID
+  runonflux.arcane_mage.deprovision:
+    api_url: "https://65.109.86.37:8006"
+    api_token: "{{ proxmox_token }}"
+    node: tsa
+    vm_id: 200
+  delegate_to: localhost
+"""
+
+RETURN = r"""
+deprovision_log:
+  description: List of deprovision step messages.
+  type: list
+  elements: str
+  returned: always
+"""
+
+import asyncio
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+async def run_deprovision(params):
+    """Execute the deprovisioning workflow."""
+    from arcane_mage import Provisioner, ProxmoxApi
+
+    token = ProxmoxApi.parse_token(params["api_token"])
+    if not token:
+        return False, ["Invalid API token format. Expected: user@realm!tokenname=tokenvalue"]
+
+    api = ProxmoxApi.from_token(params["api_url"], token, verify_ssl=params["verify_ssl"])
+
+    log_messages = []
+
+    def callback(ok, msg):
+        log_messages.append(f"{'OK' if ok else 'FAIL'}: {msg}")
+
+    async with api:
+        provisioner = Provisioner(api)
+
+        # Check if VM exists first
+        vms_res = await api.get_vms(params["node"])
+        if not vms_res:
+            return False, ["Unable to list VMs on node"]
+
+        vm_name = params.get("vm_name")
+        vm_id = params.get("vm_id")
+
+        if vm_name:
+            existing = next((v for v in vms_res.payload if v.get("name") == vm_name), None)
+        else:
+            existing = next((v for v in vms_res.payload if v.get("vmid") == vm_id), None)
+
+        if not existing:
+            identifier = vm_name or str(vm_id)
+            return True, [f"VM '{identifier}' does not exist — nothing to do"]
+
+        success = await provisioner.deprovision_vm(
+            params["node"],
+            callback=callback,
+            vm_name=vm_name,
+            vm_id=vm_id,
+        )
+
+    return success, log_messages
+
+
+def main():
+    module_args = dict(
+        api_url=dict(type="str", required=True),
+        api_token=dict(type="str", required=True, no_log=True),
+        verify_ssl=dict(type="bool", default=False),
+        node=dict(type="str", required=True),
+        vm_name=dict(type="str"),
+        vm_id=dict(type="int"),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        mutually_exclusive=[("vm_name", "vm_id")],
+        required_one_of=[("vm_name", "vm_id")],
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(changed=False, deprovision_log=["Check mode — no changes made"])
+
+    try:
+        success, log_messages = asyncio.run(run_deprovision(module.params))
+    except ImportError:
+        module.fail_json(msg="arcane-mage library is not installed. Install with: pip install arcane-mage")
+    except Exception as e:
+        module.fail_json(msg=f"Deprovision error: {e}")
+
+    if not success:
+        module.fail_json(
+            msg="Failed to deprovision VM",
+            deprovision_log=log_messages,
+        )
+
+    already_absent = any("does not exist" in m for m in log_messages)
+
+    module.exit_json(
+        changed=not already_absent,
+        deprovision_log=log_messages,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collection/runonflux/arcane_mage/plugins/modules/iso_info.py
+++ b/ansible_collection/runonflux/arcane_mage/plugins/modules/iso_info.py
@@ -118,17 +118,19 @@ async def run_iso_info(params):
             if existing:
                 return True, iso_name, False, ""
 
-        # Download via Proxmox API
-        download_url = f"https://images.runonflux.io/iso/{iso_name}"
-        res = await api.download_iso(
-            params["node"],
-            download_url,
-            iso_name,
-            params["storage_iso"],
-        )
+        # Download via Proxmox API (direct POST without verify-certificates param)
+        # URL format: https://images.runonflux.io/arcane/releases/<build>/FluxLive-<build>.iso
+        build_id = iso_name.replace("FluxLive-", "").replace(".iso", "")
+        download_url = f"https://images.runonflux.io/arcane/releases/{build_id}/{iso_name}"
+
+        endpoint = f"nodes/{params['node']}/storage/{params['storage_iso']}/download-url"
+        data = {"content": "iso", "filename": iso_name, "url": download_url}
+
+        res = await api._do_post(endpoint, data=data)
 
         if not res:
-            return False, iso_name, False, "Failed to initiate ISO download"
+            error_detail = f"status={res.status} error={res.error}" if res else "no response"
+            return False, iso_name, False, f"Failed to initiate ISO download: {error_detail}"
 
         # Wait for download task
         ok = await api.wait_for_task(res.payload, params["node"], max_wait_s=600)

--- a/ansible_collection/runonflux/arcane_mage/plugins/modules/iso_info.py
+++ b/ansible_collection/runonflux/arcane_mage/plugins/modules/iso_info.py
@@ -1,0 +1,176 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, RunOnFlux
+# License: MIT
+
+DOCUMENTATION = r"""
+---
+module: iso_info
+short_description: Get the latest ArcaneOS ISO version
+version_added: "1.0.0"
+description:
+  - Queries the Flux release API for the latest ArcaneOS ISO filename.
+  - Optionally downloads the ISO to a Proxmox node via the Proxmox API.
+  - Useful for ensuring all hosts have the latest ISO before provisioning.
+options:
+  api_url:
+    description: >
+      Proxmox API URL. Required only when I(download=true).
+    type: str
+  api_token:
+    description: >
+      Proxmox API token. Required only when I(download=true).
+    type: str
+    no_log: true
+  verify_ssl:
+    description: Whether to verify SSL certificates.
+    type: bool
+    default: false
+  node:
+    description: >
+      Proxmox cluster node name. Required when I(download=true).
+    type: str
+  storage_iso:
+    description: Storage backend for ISO files.
+    type: str
+    default: local
+  download:
+    description: >
+      Whether to download the latest ISO to the Proxmox node.
+      Uses the Proxmox API download-url endpoint.
+    type: bool
+    default: false
+requirements:
+  - "python >= 3.13"
+  - "arcane-mage >= 2.0.0"
+author:
+  - RunOnFlux
+"""
+
+EXAMPLES = r"""
+- name: Get latest ISO version
+  runonflux.arcane_mage.iso_info:
+  delegate_to: localhost
+  register: iso_result
+
+- name: Download latest ISO to Proxmox node
+  runonflux.arcane_mage.iso_info:
+    api_url: "https://65.109.86.37:8006"
+    api_token: "{{ proxmox_token }}"
+    node: tsa
+    download: true
+  delegate_to: localhost
+
+- name: Use ISO name in provisioning
+  runonflux.arcane_mage.provision:
+    iso_name: "{{ iso_result.iso_name }}"
+    # ... other params
+  delegate_to: localhost
+"""
+
+RETURN = r"""
+iso_name:
+  description: The latest ISO filename (e.g., FluxLive-1775071308.iso).
+  type: str
+  returned: success
+downloaded:
+  description: Whether the ISO was downloaded to the node.
+  type: bool
+  returned: always
+"""
+
+import asyncio
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+async def run_iso_info(params):
+    """Fetch latest ISO info and optionally download."""
+    from arcane_mage import ProxmoxApi, get_latest_iso_version
+
+    iso_name = await get_latest_iso_version()
+
+    if not iso_name:
+        return False, None, False, "Unable to fetch latest ISO version from release API"
+
+    if not params.get("download"):
+        return True, iso_name, False, ""
+
+    # Download to Proxmox node
+    if not params.get("api_url") or not params.get("api_token") or not params.get("node"):
+        return False, iso_name, False, "api_url, api_token, and node are required for download"
+
+    token = ProxmoxApi.parse_token(params["api_token"])
+    if not token:
+        return False, iso_name, False, "Invalid API token format"
+
+    api = ProxmoxApi.from_token(params["api_url"], token, verify_ssl=params["verify_ssl"])
+
+    async with api:
+        # Check if ISO already exists
+        content_res = await api.get_storage_content(params["node"], params["storage_iso"])
+        if content_res:
+            existing = next(
+                (c for c in content_res.payload if c.get("volid", "").endswith(iso_name)),
+                None,
+            )
+            if existing:
+                return True, iso_name, False, ""
+
+        # Download via Proxmox API
+        download_url = f"https://images.runonflux.io/iso/{iso_name}"
+        res = await api.download_iso(
+            params["node"],
+            download_url,
+            iso_name,
+            params["storage_iso"],
+        )
+
+        if not res:
+            return False, iso_name, False, "Failed to initiate ISO download"
+
+        # Wait for download task
+        ok = await api.wait_for_task(res.payload, params["node"], max_wait_s=600)
+        if not ok:
+            return False, iso_name, False, "ISO download task did not complete in time"
+
+    return True, iso_name, True, ""
+
+
+def main():
+    module_args = dict(
+        api_url=dict(type="str"),
+        api_token=dict(type="str", no_log=True),
+        verify_ssl=dict(type="bool", default=False),
+        node=dict(type="str"),
+        storage_iso=dict(type="str", default="local"),
+        download=dict(type="bool", default=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        required_if=[
+            ("download", True, ["api_url", "api_token", "node"]),
+        ],
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(changed=False, iso_name="", downloaded=False)
+
+    try:
+        success, iso_name, downloaded, error = asyncio.run(run_iso_info(module.params))
+    except ImportError:
+        module.fail_json(msg="arcane-mage library is not installed. Install with: pip install arcane-mage")
+    except Exception as e:
+        module.fail_json(msg=f"ISO info error: {e}")
+
+    if not success:
+        module.fail_json(msg=error, iso_name=iso_name or "")
+
+    module.exit_json(changed=downloaded, iso_name=iso_name, downloaded=downloaded)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collection/runonflux/arcane_mage/plugins/modules/provision.py
+++ b/ansible_collection/runonflux/arcane_mage/plugins/modules/provision.py
@@ -1,0 +1,450 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, RunOnFlux
+# License: MIT
+
+DOCUMENTATION = r"""
+---
+module: provision
+short_description: Provision an ArcaneOS FluxNode VM on Proxmox
+version_added: "1.0.0"
+description:
+  - Creates and optionally starts an ArcaneOS FluxNode VM on a Proxmox hypervisor.
+  - Uses the arcane-mage library to handle EFI disk, config disk, TPM 2.0, and VM creation.
+  - The VM is fully configured for unattended ArcaneOS installation.
+  - Idempotent — skips provisioning if a VM with the same name already exists.
+options:
+  api_url:
+    description: Proxmox API URL (e.g., https://192.168.1.100:8006).
+    required: true
+    type: str
+  api_token:
+    description: >
+      Proxmox API token in format C(user@realm!tokenname=tokenvalue).
+    required: true
+    type: str
+    no_log: true
+  verify_ssl:
+    description: Whether to verify SSL certificates.
+    type: bool
+    default: false
+  node:
+    description: Proxmox cluster node name (e.g., pve1).
+    required: true
+    type: str
+  vm_name:
+    description: Name for the VM on the hypervisor.
+    required: true
+    type: str
+  vm_id:
+    description: Explicit VM ID. If omitted, Proxmox assigns the next available ID.
+    type: int
+  node_tier:
+    description: FluxNode tier determining CPU, RAM, and disk allocation.
+    required: true
+    type: str
+    choices: [cumulus, nimbus, stratus]
+  network:
+    description: Proxmox network bridge name (e.g., vmbr0, vmbr4000).
+    required: true
+    type: str
+  iso_name:
+    description: >
+      FluxOS ISO filename on the hypervisor (e.g., FluxLive-1775071308.iso).
+      Must already be uploaded to the ISO storage.
+    required: true
+    type: str
+  storage_images:
+    description: Proxmox storage backend for VM disks.
+    type: str
+    default: local-lvm
+  storage_iso:
+    description: Proxmox storage backend where the ISO is stored.
+    type: str
+    default: local
+  storage_import:
+    description: Proxmox storage backend for temporary import images (needs 10+ MiB free).
+    type: str
+    default: local
+  start:
+    description: Whether to start the VM after creation.
+    type: bool
+    default: false
+  startup_config:
+    description: Proxmox startup order config (e.g., order=4,up=360).
+    type: str
+  disk_limit:
+    description: Disk I/O limit in MB/s.
+    type: int
+  cpu_limit:
+    description: CPU limit (0.0-1.0).
+    type: float
+  network_limit:
+    description: Network rate limit in MB/s.
+    type: int
+  hostname:
+    description: System hostname for the ArcaneOS installation.
+    required: true
+    type: str
+  console_password:
+    description: >
+      Password for the console user. Will be hashed with Yescrypt.
+      If omitted, console login is disabled (SSH key only).
+    type: str
+    no_log: true
+  ssh_pubkey:
+    description: SSH public key for the operator account (OpenSSH format).
+    type: str
+  keyboard_layout:
+    description: Keyboard layout for the installation.
+    type: str
+    default: us
+  keyboard_variant:
+    description: Keyboard variant.
+    type: str
+    default: ""
+  flux_id:
+    description: Flux address (14-72 characters).
+    required: true
+    type: str
+  identity_key:
+    description: FluxNode identity key in WIF format (51-52 characters).
+    required: true
+    type: str
+    no_log: true
+  tx_id:
+    description: Collateral transaction hash (exactly 64 hex characters).
+    required: true
+    type: str
+  output_id:
+    description: Collateral output index (0-999).
+    required: true
+    type: int
+  ip_allocation:
+    description: IP allocation method for the VM.
+    type: str
+    default: dhcp
+    choices: [dhcp, static]
+  ip_address:
+    description: >
+      Static IP address with prefix (e.g., 49.12.156.226/27).
+      Required when I(ip_allocation=static).
+    type: str
+  gateway:
+    description: >
+      Default gateway IP. Required when I(ip_allocation=static).
+      Must be in the same subnet as I(ip_address).
+    type: str
+  dns:
+    description: List of DNS server IPs.
+    type: list
+    elements: str
+    default: ["1.1.1.1", "8.8.8.8"]
+  upnp_port:
+    description: UPnP port for FluxNode communication.
+    type: int
+  router_address:
+    description: Router IP for UPnP (required if upnp_port is set).
+    type: str
+  notifications:
+    description: >
+      Notification configuration dict with optional keys:
+      discord (webhook_url, user_id), telegram (bot_token, chat_id),
+      email, webhook, node_name.
+    type: dict
+    default: {}
+  delegate:
+    description: >
+      Delegate configuration dict with optional keys:
+      collateral_pubkey, delegate_private_key_encrypted,
+      delegate_private_key, delegate_passphrase.
+    type: dict
+    no_log: true
+requirements:
+  - "python >= 3.13"
+  - "arcane-mage >= 2.0.0"
+author:
+  - RunOnFlux
+"""
+
+EXAMPLES = r"""
+- name: Provision a Stratus FluxNode with static IP
+  runonflux.arcane_mage.provision:
+    api_url: "https://65.109.86.37:8006"
+    api_token: "automation@pam!ansible=secret-token-value"
+    node: tsa
+    vm_name: tsa-vs1
+    node_tier: stratus
+    network: vmbr4000
+    iso_name: FluxLive-1775071308.iso
+    hostname: tsa-vs1
+    console_password: "MySecurePassword123!"
+    ssh_pubkey: "ssh-ed25519 AAAAC3..."
+    flux_id: "1ExampleFluxAddress"
+    identity_key: "L1ExampleIdentityKey"
+    tx_id: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+    output_id: 0
+    ip_allocation: static
+    ip_address: "49.12.156.226/27"
+    gateway: "49.12.156.225"
+    start: true
+  delegate_to: localhost
+
+- name: Provision with DHCP (minimal config)
+  runonflux.arcane_mage.provision:
+    api_url: "https://192.168.1.100:8006"
+    api_token: "{{ proxmox_token }}"
+    node: pve1
+    vm_name: flux-cumulus-01
+    node_tier: cumulus
+    network: vmbr0
+    iso_name: "{{ flux_iso }}"
+    hostname: flux-cumulus-01
+    flux_id: "{{ flux_id }}"
+    identity_key: "{{ identity_key }}"
+    tx_id: "{{ tx_id }}"
+    output_id: 0
+  delegate_to: localhost
+"""
+
+RETURN = r"""
+vm_id:
+  description: The VM ID assigned by Proxmox.
+  type: int
+  returned: success
+vm_name:
+  description: The VM name on the hypervisor.
+  type: str
+  returned: always
+provisioning_log:
+  description: List of provisioning step messages.
+  type: list
+  elements: str
+  returned: always
+"""
+
+import asyncio
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def build_config_dict(params):
+    """Build an ArcaneOsConfig-compatible dict from module parameters."""
+    # Fluxnode identity
+    fluxnode = {
+        "identity": {
+            "flux_id": params["flux_id"],
+            "identity_key": params["identity_key"],
+            "tx_id": params["tx_id"],
+            "output_id": params["output_id"],
+        },
+    }
+
+    # UPnP network config
+    if params.get("upnp_port"):
+        fluxnode["network"] = {
+            "upnp_port": params["upnp_port"],
+        }
+        if params.get("router_address"):
+            fluxnode["network"]["router_address"] = params["router_address"]
+
+    # Notifications
+    if params.get("notifications"):
+        fluxnode["notifications"] = params["notifications"]
+
+    # Delegate
+    if params.get("delegate"):
+        fluxnode["delegate"] = params["delegate"]
+
+    # System
+    system = {
+        "hostname": params["hostname"],
+        "keyboard": {
+            "layout": params["keyboard_layout"],
+            "variant": params["keyboard_variant"],
+        },
+    }
+
+    if params.get("ssh_pubkey"):
+        system["ssh_pubkey"] = params["ssh_pubkey"]
+
+    # Network
+    network = {"ip_allocation": params["ip_allocation"]}
+
+    if params["ip_allocation"] == "static":
+        network["address_config"] = {
+            "address": params["ip_address"],
+            "gateway": params["gateway"],
+        }
+        if params.get("dns"):
+            network["address_config"]["dns"] = params["dns"]
+
+    # Hypervisor
+    hypervisor = {
+        "node": params["node"],
+        "vm_name": params["vm_name"],
+        "node_tier": params["node_tier"],
+        "network": params["network"],
+        "iso_name": params["iso_name"],
+        "storage_images": params["storage_images"],
+        "storage_iso": params["storage_iso"],
+        "storage_import": params["storage_import"],
+        "start_on_creation": params["start"],
+    }
+
+    if params.get("vm_id") is not None:
+        hypervisor["vm_id"] = params["vm_id"]
+    if params.get("startup_config"):
+        hypervisor["startup_config"] = params["startup_config"]
+    if params.get("disk_limit") is not None:
+        hypervisor["disk_limit"] = params["disk_limit"]
+    if params.get("cpu_limit") is not None:
+        hypervisor["cpu_limit"] = params["cpu_limit"]
+    if params.get("network_limit") is not None:
+        hypervisor["network_limit"] = params["network_limit"]
+
+    return {
+        "fluxnode": fluxnode,
+        "system": system,
+        "network": network,
+        "hypervisor": hypervisor,
+    }
+
+
+async def run_provision(params):
+    """Execute the provisioning workflow."""
+    from arcane_mage import ArcaneOsConfig, HashedPassword, Provisioner, ProxmoxApi
+
+    token = ProxmoxApi.parse_token(params["api_token"])
+    if not token:
+        return False, None, ["Invalid API token format. Expected: user@realm!tokenname=tokenvalue"]
+
+    api = ProxmoxApi.from_token(params["api_url"], token, verify_ssl=params["verify_ssl"])
+
+    log_messages = []
+    vm_id = None
+
+    def callback(ok, msg):
+        log_messages.append(f"{'OK' if ok else 'FAIL'}: {msg}")
+
+    config_dict = build_config_dict(params)
+
+    # Hash the console password if provided
+    if params.get("console_password"):
+        hp = HashedPassword(password=params["console_password"])
+        config_dict["system"]["hashed_console"] = hp.hash()
+
+    try:
+        config = ArcaneOsConfig.from_dict(config_dict)
+    except (ValueError, Exception) as e:
+        return False, None, [f"Configuration validation failed: {e}"]
+
+    async with api:
+        # Check if VM already exists
+        vms_res = await api.get_vms(params["node"])
+        if vms_res:
+            existing = next(
+                (v for v in vms_res.payload if v.get("name") == params["vm_name"]),
+                None,
+            )
+            if existing:
+                return True, existing.get("vmid"), [f"VM '{params['vm_name']}' already exists (id={existing['vmid']})"]
+
+        provisioner = Provisioner(api)
+        success = await provisioner.provision_node(config, callback=callback)
+
+        if success and config.hypervisor:
+            # Get the VM ID from Proxmox
+            vms_res = await api.get_vms(params["node"])
+            if vms_res:
+                vm = next(
+                    (v for v in vms_res.payload if v.get("name") == params["vm_name"]),
+                    None,
+                )
+                if vm:
+                    vm_id = vm.get("vmid")
+
+    return success, vm_id, log_messages
+
+
+def main():
+    module_args = dict(
+        api_url=dict(type="str", required=True),
+        api_token=dict(type="str", required=True, no_log=True),
+        verify_ssl=dict(type="bool", default=False),
+        node=dict(type="str", required=True),
+        vm_name=dict(type="str", required=True),
+        vm_id=dict(type="int"),
+        node_tier=dict(type="str", required=True, choices=["cumulus", "nimbus", "stratus"]),
+        network=dict(type="str", required=True),
+        iso_name=dict(type="str", required=True),
+        storage_images=dict(type="str", default="local-lvm"),
+        storage_iso=dict(type="str", default="local"),
+        storage_import=dict(type="str", default="local"),
+        start=dict(type="bool", default=False),
+        startup_config=dict(type="str"),
+        disk_limit=dict(type="int"),
+        cpu_limit=dict(type="float"),
+        network_limit=dict(type="int"),
+        hostname=dict(type="str", required=True),
+        console_password=dict(type="str", no_log=True),
+        ssh_pubkey=dict(type="str"),
+        keyboard_layout=dict(type="str", default="us"),
+        keyboard_variant=dict(type="str", default=""),
+        flux_id=dict(type="str", required=True),
+        identity_key=dict(type="str", required=True, no_log=True),
+        tx_id=dict(type="str", required=True),
+        output_id=dict(type="int", required=True),
+        ip_allocation=dict(type="str", default="dhcp", choices=["dhcp", "static"]),
+        ip_address=dict(type="str"),
+        gateway=dict(type="str"),
+        dns=dict(type="list", elements="str", default=["1.1.1.1", "8.8.8.8"]),
+        upnp_port=dict(type="int"),
+        router_address=dict(type="str"),
+        notifications=dict(type="dict", default={}),
+        delegate=dict(type="dict", no_log=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        required_if=[
+            ("ip_allocation", "static", ["ip_address", "gateway"]),
+        ],
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=False,
+            vm_name=module.params["vm_name"],
+            provisioning_log=["Check mode — no changes made"],
+        )
+
+    try:
+        success, vm_id, log_messages = asyncio.run(run_provision(module.params))
+    except ImportError:
+        module.fail_json(msg="arcane-mage library is not installed. Install with: pip install arcane-mage")
+    except Exception as e:
+        module.fail_json(msg=f"Provisioning error: {e}")
+
+    if not success:
+        module.fail_json(
+            msg=f"Failed to provision VM '{module.params['vm_name']}'",
+            vm_name=module.params["vm_name"],
+            provisioning_log=log_messages,
+        )
+
+    # VM already existed = no change
+    already_existed = any("already exists" in m for m in log_messages)
+
+    module.exit_json(
+        changed=not already_existed,
+        vm_id=vm_id,
+        vm_name=module.params["vm_name"],
+        provisioning_log=log_messages,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collection/runonflux/arcane_mage/plugins/modules/provision.py
+++ b/ansible_collection/runonflux/arcane_mage/plugins/modules/provision.py
@@ -145,7 +145,10 @@ options:
     description: UPnP port for FluxNode communication.
     type: int
   router_address:
-    description: Router IP for UPnP (required if upnp_port is set).
+    description: >
+      Router IP for UPnP. Pass an empty string to explicitly clear the field
+      when UPnP is not used — some daemon versions require the key to be
+      present as a string.
     type: str
   notifications:
     description: >
@@ -241,13 +244,16 @@ def build_config_dict(params):
         },
     }
 
-    # UPnP network config
+    # Fluxnode network config — upnp_port and router_address are independent.
+    # Use `is not None` so empty-string router_address (the "UPnP disabled"
+    # sentinel for public-IP nodes) is preserved instead of being dropped.
+    network = {}
     if params.get("upnp_port"):
-        fluxnode["network"] = {
-            "upnp_port": params["upnp_port"],
-        }
-        if params.get("router_address"):
-            fluxnode["network"]["router_address"] = params["router_address"]
+        network["upnp_port"] = params["upnp_port"]
+    if params.get("router_address") is not None:
+        network["router_address"] = params["router_address"]
+    if network:
+        fluxnode["network"] = network
 
     # Notifications
     if params.get("notifications"):

--- a/ansible_collection/runonflux/arcane_mage/plugins/modules/status.py
+++ b/ansible_collection/runonflux/arcane_mage/plugins/modules/status.py
@@ -1,0 +1,153 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, RunOnFlux
+# License: MIT
+
+DOCUMENTATION = r"""
+---
+module: status
+short_description: Check FluxNode VM status on Proxmox
+version_added: "1.0.0"
+description:
+  - Lists all VMs on a Proxmox node and their current status.
+  - Optionally filter by VM name to check a specific node.
+options:
+  api_url:
+    description: Proxmox API URL.
+    required: true
+    type: str
+  api_token:
+    description: Proxmox API token in format C(user@realm!tokenname=tokenvalue).
+    required: true
+    type: str
+    no_log: true
+  verify_ssl:
+    description: Whether to verify SSL certificates.
+    type: bool
+    default: false
+  node:
+    description: Proxmox cluster node name.
+    required: true
+    type: str
+  vm_name:
+    description: Filter results to a specific VM name.
+    type: str
+  vm_id:
+    description: Filter results to a specific VM ID.
+    type: int
+requirements:
+  - "python >= 3.13"
+  - "arcane-mage >= 2.0.0"
+author:
+  - RunOnFlux
+"""
+
+EXAMPLES = r"""
+- name: List all VMs on a node
+  runonflux.arcane_mage.status:
+    api_url: "https://65.109.86.37:8006"
+    api_token: "{{ proxmox_token }}"
+    node: tsa
+  delegate_to: localhost
+  register: vm_status
+
+- name: Check specific VM status
+  runonflux.arcane_mage.status:
+    api_url: "https://65.109.86.37:8006"
+    api_token: "{{ proxmox_token }}"
+    node: tsa
+    vm_name: tsa-vs1
+  delegate_to: localhost
+"""
+
+RETURN = r"""
+vms:
+  description: List of VMs with their status.
+  type: list
+  elements: dict
+  returned: always
+  contains:
+    vmid:
+      description: VM ID.
+      type: int
+    name:
+      description: VM name.
+      type: str
+    status:
+      description: VM status (running, stopped, etc.).
+      type: str
+    cpu:
+      description: CPU usage.
+      type: float
+    mem:
+      description: Memory usage in bytes.
+      type: int
+    maxmem:
+      description: Maximum memory in bytes.
+      type: int
+    disk:
+      description: Disk usage in bytes.
+      type: int
+    maxdisk:
+      description: Maximum disk in bytes.
+      type: int
+"""
+
+import asyncio
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+async def run_status(params):
+    """Fetch VM status from Proxmox."""
+    from arcane_mage import ProxmoxApi
+
+    token = ProxmoxApi.parse_token(params["api_token"])
+    if not token:
+        return False, [], "Invalid API token format"
+
+    api = ProxmoxApi.from_token(params["api_url"], token, verify_ssl=params["verify_ssl"])
+
+    async with api:
+        vms_res = await api.get_vms(params["node"])
+        if not vms_res:
+            return False, [], f"Unable to list VMs on {params['node']}"
+
+        vms = vms_res.payload
+
+        if params.get("vm_name"):
+            vms = [v for v in vms if v.get("name") == params["vm_name"]]
+        elif params.get("vm_id") is not None:
+            vms = [v for v in vms if v.get("vmid") == params["vm_id"]]
+
+    return True, vms, ""
+
+
+def main():
+    module_args = dict(
+        api_url=dict(type="str", required=True),
+        api_token=dict(type="str", required=True, no_log=True),
+        verify_ssl=dict(type="bool", default=False),
+        node=dict(type="str", required=True),
+        vm_name=dict(type="str"),
+        vm_id=dict(type="int"),
+    )
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    try:
+        success, vms, error = asyncio.run(run_status(module.params))
+    except ImportError:
+        module.fail_json(msg="arcane-mage library is not installed. Install with: pip install arcane-mage")
+    except Exception as e:
+        module.fail_json(msg=f"Status check error: {e}")
+
+    if not success:
+        module.fail_json(msg=error)
+
+    module.exit_json(changed=False, vms=vms)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collection/runonflux/arcane_mage/plugins/modules/validate.py
+++ b/ansible_collection/runonflux/arcane_mage/plugins/modules/validate.py
@@ -1,0 +1,186 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, RunOnFlux
+# License: MIT
+
+DOCUMENTATION = r"""
+---
+module: validate
+short_description: Pre-flight validation for FluxNode provisioning
+version_added: "1.0.0"
+description:
+  - Validates that a Proxmox hypervisor is ready for FluxNode provisioning.
+  - Checks API version, storage backends, ISO availability, and network bridge.
+  - Does not make any changes.
+options:
+  api_url:
+    description: Proxmox API URL.
+    required: true
+    type: str
+  api_token:
+    description: Proxmox API token in format C(user@realm!tokenname=tokenvalue).
+    required: true
+    type: str
+    no_log: true
+  verify_ssl:
+    description: Whether to verify SSL certificates.
+    type: bool
+    default: false
+  node:
+    description: Proxmox cluster node name.
+    required: true
+    type: str
+  network:
+    description: Network bridge to validate.
+    required: true
+    type: str
+  iso_name:
+    description: ISO filename to check for.
+    required: true
+    type: str
+  storage_images:
+    description: Storage backend for VM disks.
+    type: str
+    default: local-lvm
+  storage_iso:
+    description: Storage backend for ISOs.
+    type: str
+    default: local
+  storage_import:
+    description: Storage backend for temporary imports.
+    type: str
+    default: local
+requirements:
+  - "python >= 3.13"
+  - "arcane-mage >= 2.0.0"
+author:
+  - RunOnFlux
+"""
+
+EXAMPLES = r"""
+- name: Validate hypervisor is ready
+  runonflux.arcane_mage.validate:
+    api_url: "https://65.109.86.37:8006"
+    api_token: "{{ proxmox_token }}"
+    node: tsa
+    network: vmbr4000
+    iso_name: FluxLive-1775071308.iso
+  delegate_to: localhost
+"""
+
+RETURN = r"""
+api_version:
+  description: Proxmox API version.
+  type: str
+  returned: success
+checks:
+  description: Results of each validation check.
+  type: dict
+  returned: always
+  contains:
+    api_version:
+      description: Whether API version meets minimum.
+      type: bool
+    storage:
+      description: Whether storage backends are valid.
+      type: bool
+    iso:
+      description: Whether the ISO exists.
+      type: bool
+    network:
+      description: Whether the network bridge exists.
+      type: bool
+"""
+
+import asyncio
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+async def run_validate(params):
+    """Run pre-flight validation checks."""
+    from arcane_mage import Provisioner, ProxmoxApi
+
+    token = ProxmoxApi.parse_token(params["api_token"])
+    if not token:
+        return False, {}, "", "Invalid API token format"
+
+    api = ProxmoxApi.from_token(params["api_url"], token, verify_ssl=params["verify_ssl"])
+
+    checks = {}
+    errors = []
+    api_version = ""
+
+    async with api:
+        provisioner = Provisioner(api)
+
+        # API version
+        version_ok, version_msg = await provisioner.validate_api_version(params["node"])
+        checks["api_version"] = version_ok
+        if version_ok:
+            api_version = version_msg
+        else:
+            errors.append(f"API version: {version_msg}")
+
+        # Storage
+        storage_ok, storage_msg = await provisioner.validate_storage(
+            params["node"],
+            params["storage_iso"],
+            params["storage_images"],
+            params["storage_import"],
+        )
+        checks["storage"] = storage_ok
+        if not storage_ok:
+            errors.append(f"Storage: {storage_msg}")
+
+        # ISO
+        iso_ok = await provisioner.validate_iso_version(
+            params["node"], params["iso_name"], params["storage_iso"]
+        )
+        checks["iso"] = iso_ok
+        if not iso_ok:
+            errors.append(f"ISO '{params['iso_name']}' not found on storage '{params['storage_iso']}'")
+
+        # Network
+        network_ok = await provisioner.validate_network(params["node"], params["network"])
+        checks["network"] = network_ok
+        if not network_ok:
+            errors.append(f"Network bridge '{params['network']}' not found")
+
+    all_ok = all(checks.values())
+    error_msg = "; ".join(errors) if errors else ""
+
+    return all_ok, checks, api_version, error_msg
+
+
+def main():
+    module_args = dict(
+        api_url=dict(type="str", required=True),
+        api_token=dict(type="str", required=True, no_log=True),
+        verify_ssl=dict(type="bool", default=False),
+        node=dict(type="str", required=True),
+        network=dict(type="str", required=True),
+        iso_name=dict(type="str", required=True),
+        storage_images=dict(type="str", default="local-lvm"),
+        storage_iso=dict(type="str", default="local"),
+        storage_import=dict(type="str", default="local"),
+    )
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    try:
+        success, checks, api_version, error = asyncio.run(run_validate(module.params))
+    except ImportError:
+        module.fail_json(msg="arcane-mage library is not installed. Install with: pip install arcane-mage")
+    except Exception as e:
+        module.fail_json(msg=f"Validation error: {e}")
+
+    if not success:
+        module.fail_json(msg=f"Validation failed: {error}", checks=checks, api_version=api_version)
+
+    module.exit_json(changed=False, checks=checks, api_version=api_version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `runonflux.arcane_mage` Ansible collection wrapping the arcane-mage library
- 5 modules: `provision`, `deprovision`, `status`, `validate`, `iso_info`
- Full DOCUMENTATION/EXAMPLES/RETURN blocks for `ansible-doc` support
- All modules are idempotent and support `--check` mode

## Modules

| Module | Description |
|--------|-------------|
| `provision` | Create ArcaneOS FluxNode VMs (UEFI, TPM 2.0, config disk, unattended install) |
| `deprovision` | Stop and delete VMs |
| `status` | Check VM status on a Proxmox node |
| `validate` | Pre-flight checks (API version, storage, ISO, network) |
| `iso_info` | Get latest ISO version, optionally download to host |

## Install from this branch

```bash
ansible-galaxy collection install git+https://github.com/RunOnFlux/arcane-mage.git#ansible_collection/runonflux/arcane_mage,feat/ansible-collection
```

## Test plan

- [ ] Build collection with `ansible-galaxy collection build`
- [ ] Install and verify module docs with `ansible-doc runonflux.arcane_mage.provision`
- [ ] Run `validate` module against a Proxmox host
- [ ] Run `provision` module to create a test VM
- [ ] Run `deprovision` module to clean up

🤖 Generated with [Claude Code](https://claude.com/claude-code)