### PR TITLE
Add Proxmox cluster support with batch provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.1.0
+
+### Added
+
+- **Proxmox cluster support**: detect cluster membership on connection; run pre-flight checks (quorum, target node online, cluster-wide VM name uniqueness) before provisioning. Backwards compatible — standalone Proxmox servers behave identically.
+- **`ClusterContext` model** (`models/cluster.py`): topology detection, per-node online/offline status, shared-vs-local storage queries.
+- **`BatchProvisioner`** (`batch.py`): orchestrates provisioning across multiple cluster nodes with EFI upload dedup on shared storage and failure recovery.
+- **`Provisioner.detect_cluster()`**: populates cluster context during construction; returns `None` for standalone Proxmox servers.
+- **`HypervisorConfig.force_standalone`**: escape hatch to skip cluster detection on a specific hypervisor.
+- **TUI**: cluster info label (name, node count, quorum state), new "Status" column showing node online/offline, quorum-lost warning disables provisioning.
+- **CLI**: `provision` integrates `BatchProvisioner`; JSON output shape unchanged; new "Cluster pre-flight checks passed" step reported alongside existing steps.
+
+### Fixed
+
+- **`ProxmoxApi.get_vms()`**: returned `payload=None` for offline cluster nodes, causing `build_fluxnode_table` to crash with `TypeError: 'NoneType' object is not iterable`. `discover_nodes()` now coerces `None → []` with defensive guards in `welcome_proxmox.py` and `__main__.py`. Regression test added.
+- **CLI provision summary**: "Provisioned successfully"/"Provisioning failed" lines were printed in a trailing loop, stacking under the last node's block. Each summary is now prefixed with `{hostname}:` and self-describing per node.
+
 ## 2.0.0
 
 ### Breaking Changes

--- a/TESTPLAN.md
+++ b/TESTPLAN.md
@@ -1,0 +1,93 @@
+# Cluster Support — Test Plan
+
+Pre-PR verification checklist for the cluster-architecture branch.
+
+## Running the TUI
+
+The TUI is an HTTP client — it connects to Proxmox via API and does not need to run on a Proxmox node. Run from any machine with network access to the Proxmox API:
+
+```
+cd ~/Git/arcane-mage_flux
+.venv/bin/arcane-mage
+```
+
+Requires Python 3.13+ and `pip install -e ".[tui]"` in the venv. A `fluxnodes.yaml` with hypervisor config is needed.
+
+**Read-only tests (no VMs needed):** 2, 5, 8, 14, 15, 16 — just connect and view the UI.
+**Provisioning tests (create/delete VMs):** 1, 3, 6, 7, 9, 10, 11, 12, 13, 17.
+
+## Unit Tests (automated)
+
+- [x] `pytest tests/` — 211 passed
+
+## Integration Tests (manual)
+
+### 1. Standalone Server (pve20 or pve40)
+Connect to an R820 (not in the cluster). Verify `cluster` is `None`, all provisioning behavior identical to before.
+
+### 2. Cluster Detection (moltentech)
+Connect to any node in the `moltentech` cluster. Verify the TUI shows cluster name, node count (6), and quorum: ok.
+
+### 3. Node Offline Check
+Shut down or fence a non-critical cluster node (e.g. pve65). Provision a VM targeting that node. Should block with `"Node 'pve65' is offline in cluster"`.
+
+### 4. Quorum Loss
+Hard to test safely with a 6-node cluster (need 4 nodes down). Could simulate by adding `force_standalone` to skip this in production and unit-test coverage handles the logic. Or test in a throwaway 3-node cluster where killing 2 breaks quorum.
+
+### 5. VM Name Uniqueness
+Create a VM on one cluster node, then try to provision a second VM with the same name on a different node. Should block with `"VM name '...' already exists on node '...'"`.
+
+### 6. Shared Storage EFI Dedup
+Requires shared storage (NFS/Ceph) on the cluster. Provision 2+ VMs on different nodes using the same shared storage. Watch the callbacks — first should say "EFI image uploaded", subsequent should say "EFI image upload skipped (shared storage)".
+
+### 7. Local Storage (unchanged behavior)
+Provision 2+ VMs on local storage. Each should upload EFI independently, only the last should delete it.
+
+### 8. `force_standalone: true`
+Add `force_standalone: true` to a hypervisor config YAML entry pointing at a cluster node. Verify no cluster info is shown, no pre-flight cluster checks run.
+
+### 9. CLI Provision
+Run `arcane-mage provision` against the cluster. Verify output shows cluster pre-flight checks and correct EFI skip/delete behavior.
+
+### 9a. CLI Provision JSON Output (Moltentech provisioner compat)
+Run `arcane-mage provision --json -c <yaml> --url <url> --token <token>` (the exact invocation the Moltentech provisioner container uses). Verify:
+- JSON output is `{"ok": true/false, "nodes": [{"hostname": "...", "ok": true/false, "steps": [...]}]}`
+- The extra "Cluster pre-flight checks passed" step message doesn't break anything
+- Exit code 0 on success, 1 on failure (unchanged)
+
+### 10. Single-Node TUI Provision (regression)
+Click a single row in the TUI DataTable and provision one VM. Verify it still works identically — no cluster-related regressions in the single-node path.
+
+### 11. TUI Deprovision (regression)
+Deprovision a VM through the TUI. Verify deprovisioning is unaffected (it should be — no cluster changes touch deprovision).
+
+### 12. CLI Deprovision (regression)
+Run `arcane-mage deprovision` against a cluster node. Verify it works unchanged.
+
+### 13. Ansible Module (regression)
+Run the Ansible `provision` module. It creates `Provisioner(api)` without cluster, so it should behave identically to before. Verify no errors.
+
+### 14. DataTable Column Alignment
+Open the TUI against both a standalone server and a cluster. Verify the new "Status" column renders correctly — shows "online"/"offline" for cluster, empty string for standalone. Check that no columns are misaligned.
+
+### 15. Cluster Info Label Hide/Show
+Switch between hypervisors in the TUI dropdown — from a cluster node to a standalone (or vice versa). Verify the cluster info label appears/disappears correctly and doesn't leave stale text.
+
+### 16. API Auth Failure Graceful Handling
+Connect with invalid credentials to a cluster. Verify the error path still works cleanly — `from_hypervisor_config` returns `None`, no crash from cluster detection on a failed connection.
+
+### 17. `total_steps` Count in TUI
+When `skip_efi_upload=True`, the provisioning step count shows "EFI image upload skipped" instead of "EFI image uploaded", but it's still counted as a step. Verify the progress indicator (e.g. "Step 7/9") still tracks correctly and doesn't show the wrong total.
+
+### 18. Moltentech Provisioner Container
+The provisioner container (`apps/provisioner/`) calls arcane-mage via CLI (`execFile`). It is affected by our changes because:
+- `arcane-mage provision` now calls `detect_cluster()` (2 extra API calls per provision)
+- Cluster pre-flight checks run if the Proxmox host is in a cluster
+
+**What to verify:**
+- Rebuild the provisioner Docker image (it copies `arcane-mage/` into the container)
+- Trigger a provision job and verify it succeeds with unchanged JSON output
+- Trigger a deprovision job and verify it succeeds (deprovision path is untouched)
+- Check watchdog.py still runs cleanly (it only imports `HypervisorConfig`, `ProxmoxApi` — no Provisioner)
+
+**Note:** The provisioner Dockerfile copies `arcane-mage/` from the repo root. If deploying, the updated arcane-mage source must be in `~/Git/moltentech/arcane-mage/` (currently it's a separate copy — check if it's a symlink or needs manual sync).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcane-mage"
-version = "2.0.0"
+version = "2.1.0"
 description = "Automation helper for Fluxnodes"
 readme = "README.md"
 authors = [

--- a/src/arcane_mage/__init__.py
+++ b/src/arcane_mage/__init__.py
@@ -1,6 +1,10 @@
 """arcane-mage: Fluxnode provisioning library and tools."""
 
+from .batch import BatchProvisioner, BatchResult, NodePlan
 from .models import (
+    ClusterContext,
+    ClusterNode,
+    ClusterStorage,
     AddressConfig,
     ArcaneCreatorConfig,
     ArcaneOsConfig,
@@ -23,6 +27,12 @@ from .provisioner import TIER_CONFIG, HypervisorDiscovery, Provisioner, get_late
 from .proxmox import ApiResponse, ParsedToken, ParsedUserPass, ProxmoxApi, ResolvedConnection
 
 __all__ = [
+    "BatchProvisioner",
+    "BatchResult",
+    "ClusterContext",
+    "ClusterNode",
+    "ClusterStorage",
+    "NodePlan",
     "TIER_CONFIG",
     "AddressConfig",
     "ApiResponse",

--- a/src/arcane_mage/__main__.py
+++ b/src/arcane_mage/__main__.py
@@ -21,7 +21,8 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from .models import ArcaneCreatorConfig, ArcaneOsConfigGroup
+from .batch import BatchProvisioner
+from .models import ArcaneCreatorConfig, ArcaneOsConfig, ArcaneOsConfigGroup
 from .proxmox import ProxmoxApi, ResolvedConnection
 
 app = typer.Typer(
@@ -232,6 +233,7 @@ def provision(
     async def run():
         async with ProxmoxApi.from_token(conn.url, conn.token) as api:
             provisioner = Provisioner(api)
+            await provisioner.detect_cluster()
 
             nodes = list(configs)
             if node_filter:
@@ -240,35 +242,41 @@ def provision(
             if not nodes:
                 raise CliError(f"No nodes match filter '{node_filter}'")
 
-            results = []
-            all_ok = True
+            # Apply --start/--no-start override before batching
             for node in nodes:
-                hostname = node.system.hostname
-
                 if start is not None and node.hypervisor:
                     node.hypervisor.start_on_creation = start
 
-                steps: list[dict[str, object]] = []
+            # Per-node step tracking for JSON output
+            node_steps: dict[str, list[dict[str, object]]] = {}
 
-                def callback(ok: bool, msg: str):
-                    steps.append({"ok": ok, "message": msg})
+            def batch_callback(fluxnode: ArcaneOsConfig, ok: bool, msg: str):
+                hostname = fluxnode.system.hostname
+                if hostname not in node_steps:
+                    node_steps[hostname] = []
                     if not use_json:
-                        mark = _CHECK_MARK if ok else _CROSS_MARK
-                        console.print(f"  {mark} {msg}")
+                        console.print(f"\n[bold]{hostname}[/bold]")
+                node_steps[hostname].append({"ok": ok, "message": msg})
+                if not use_json:
+                    mark = _CHECK_MARK if ok else _CROSS_MARK
+                    console.print(f"  {mark} {msg}")
+
+            batch = BatchProvisioner(provisioner, provisioner.cluster)
+            batch_results = await batch.provision_batch(nodes, callback=batch_callback)
+
+            results = []
+            all_ok = True
+            for br in batch_results:
+                hostname = br.fluxnode.system.hostname
+                results.append({"hostname": hostname, "ok": br.ok, "steps": node_steps.get(hostname, [])})
 
                 if not use_json:
-                    console.print(f"\n[bold]{hostname}[/bold]")
-
-                result = await provisioner.provision_node(node, callback=callback)
-                results.append({"hostname": hostname, "ok": result, "steps": steps})
-
-                if not use_json:
-                    if result:
-                        console.print(f"  [bold green]Provisioned successfully[/bold green]")
+                    if br.ok:
+                        console.print(f"[bold green]{hostname}: Provisioned successfully[/bold green]")
                     else:
-                        console.print(f"  [bold red]Provisioning failed[/bold red]")
+                        console.print(f"[bold red]{hostname}: Provisioning failed[/bold red]")
 
-                if not result:
+                if not br.ok:
                     all_ok = False
 
             if use_json:
@@ -687,7 +695,7 @@ def status(
                     continue
 
                 provisioned = False
-                vms = discovery.provisioned_vms.get(hyper.node, [])
+                vms = discovery.provisioned_vms.get(hyper.node) or []
                 for vm in vms:
                     if vm.get("name") == hyper.vm_name:
                         provisioned = True

--- a/src/arcane_mage/arcane_mage.py
+++ b/src/arcane_mage/arcane_mage.py
@@ -9,6 +9,7 @@ from textual.app import App
 from textual.screen import Screen
 from textual.worker import Worker, WorkerCancelled
 
+from .batch import BatchProvisioner
 from .messages import ScreenRequested, UpdateDefaultPage
 from .models import (
     ArcaneCreatorConfig,
@@ -77,7 +78,10 @@ class ArcaneMage(App):
         screen.validate_hypervisors()
 
     async def provision_node_callback(
-        self, fluxnode: ArcaneOsConfig | None, delete_efi: bool = True
+        self,
+        fluxnode: ArcaneOsConfig | None,
+        delete_efi: bool = True,
+        skip_efi_upload: bool = False,
     ) -> Worker | None:
         if not fluxnode or not fluxnode.hypervisor:
             return None
@@ -97,6 +101,7 @@ class ArcaneMage(App):
             fluxnode,
             callback=info_screen.update_callback,
             delete_efi=delete_efi,
+            skip_efi_upload=skip_efi_upload,
         )
 
         return worker
@@ -198,7 +203,18 @@ class ArcaneMage(App):
 
         hashed_password = configured_node.system.hashed_console
 
-        worker = await self.provision_node_callback(configured_node)
+        # Build a cluster-aware batch plan for EFI upload/delete optimization
+        batch = BatchProvisioner(screen.provisioner, screen.provisioner.cluster)
+        plan = batch._build_plan(list(provisionable_nodes))
+
+        # First node uses plan[0] flags
+        first_plan = plan[0] if plan else None
+
+        worker = await self.provision_node_callback(
+            configured_node,
+            delete_efi=first_plan.delete_efi if first_plan else True,
+            skip_efi_upload=first_plan.skip_efi_upload if first_plan else False,
+        )
 
         if not worker:
             return
@@ -224,14 +240,18 @@ class ArcaneMage(App):
             self.pop_screen()
 
         # we leave the info screen to display on error, otherwise pop
-        for fluxnode in provisionable_nodes.rest:
+        for i, fluxnode in enumerate(provisionable_nodes.rest):
             needs_pop = True
             fluxnode.system.hashed_console = hashed_password
 
             last = fluxnode == provisionable_nodes.last
+            # plan index is i+1 since plan[0] was the first node
+            node_plan = plan[i + 1] if i + 1 < len(plan) else None
 
             worker = await self.provision_node_callback(
-                fluxnode, delete_efi=last
+                fluxnode,
+                delete_efi=node_plan.delete_efi if node_plan else last,
+                skip_efi_upload=node_plan.skip_efi_upload if node_plan else False,
             )
 
             if not worker:

--- a/src/arcane_mage/batch.py
+++ b/src/arcane_mage/batch.py
@@ -1,0 +1,137 @@
+"""Batch provisioning with cluster-aware optimizations."""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from .models import ArcaneOsConfig
+from .models.cluster import ClusterContext
+from .provisioner import Provisioner
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class NodePlan:
+    """Per-node provisioning instructions computed by BatchProvisioner."""
+
+    fluxnode: ArcaneOsConfig
+    skip_efi_upload: bool = False
+    delete_efi: bool = True
+
+
+@dataclass
+class BatchResult:
+    """Result of provisioning a single node within a batch."""
+
+    fluxnode: ArcaneOsConfig
+    ok: bool
+
+
+class BatchProvisioner:
+    """Coordinates provisioning multiple VMs with cluster-aware optimizations.
+
+    Handles upload deduplication for shared storage, failure recovery
+    (re-uploads if a prior node on shared storage failed), and EFI
+    cleanup sequencing.
+    """
+
+    def __init__(
+        self,
+        provisioner: Provisioner,
+        cluster: ClusterContext | None = None,
+    ) -> None:
+        self.provisioner = provisioner
+        self.cluster = cluster
+
+    def _build_plan(self, nodes: list[ArcaneOsConfig]) -> list[NodePlan]:
+        """Build provisioning plan with EFI upload/delete optimization.
+
+        Groups nodes by ``(hypervisor_node, storage_import)``. For shared
+        storage, only the first node in each group uploads the EFI image, and
+        only the last deletes it. For non-shared storage (or no cluster
+        context), every node uploads and only the last in the full batch
+        deletes — matching current behaviour.
+        """
+        if not nodes:
+            return []
+
+        # Group indices by (hypervisor_node, storage_import)
+        groups: dict[tuple[str, str], list[int]] = defaultdict(list)
+        for i, node in enumerate(nodes):
+            hv = node.hypervisor
+            if hv:
+                groups[(hv.node, hv.storage_import)].append(i)
+
+        plans = [NodePlan(fluxnode=n) for n in nodes]
+
+        for (_, storage), indices in groups.items():
+            is_shared = (
+                self.cluster is not None
+                and self.cluster.is_storage_shared(storage)
+            )
+
+            if is_shared:
+                # Shared storage: upload once, delete once
+                for j, idx in enumerate(indices):
+                    plans[idx].skip_efi_upload = j > 0  # only first uploads
+                    plans[idx].delete_efi = j == len(indices) - 1  # only last deletes
+            else:
+                # Local storage: every node uploads, only last deletes
+                for j, idx in enumerate(indices):
+                    plans[idx].skip_efi_upload = False
+                    plans[idx].delete_efi = j == len(indices) - 1
+
+        return plans
+
+    async def provision_batch(
+        self,
+        nodes: list[ArcaneOsConfig],
+        callback: Callable[[ArcaneOsConfig, bool, str], None] | None = None,
+    ) -> list[BatchResult]:
+        """Provision multiple nodes with cluster-aware optimizations.
+
+        Builds an upload plan based on storage topology, iterates through
+        nodes, and adjusts the plan on failure. The callback receives
+        ``(fluxnode, ok, message)`` so callers know which node each status
+        update belongs to.
+
+        Does not short-circuit on failure — all nodes are attempted and results
+        are returned for every node.
+        """
+        plan = self._build_plan(nodes)
+        results: list[BatchResult] = []
+
+        # Track which groups have had a successful EFI upload
+        efi_uploaded: set[tuple[str, str]] = set()
+
+        for i, entry in enumerate(plan):
+            hv = entry.fluxnode.hypervisor
+            group_key = (hv.node, hv.storage_import) if hv else ("", "")
+
+            # Failure recovery: if we should skip upload but EFI was never
+            # successfully uploaded for this group, upload anyway.
+            skip = entry.skip_efi_upload
+            if skip and group_key not in efi_uploaded:
+                skip = False
+
+            def node_callback(ok: bool, msg: str, _node=entry.fluxnode) -> None:
+                if callback:
+                    callback(_node, ok, msg)
+
+            ok = await self.provisioner.provision_node(
+                entry.fluxnode,
+                callback=node_callback,
+                delete_efi=entry.delete_efi,
+                skip_efi_upload=skip,
+            )
+
+            if ok and not skip:
+                efi_uploaded.add(group_key)
+
+            results.append(BatchResult(fluxnode=entry.fluxnode, ok=ok))
+
+        return results

--- a/src/arcane_mage/models/__init__.py
+++ b/src/arcane_mage/models/__init__.py
@@ -1,3 +1,6 @@
+from .cluster import ClusterContext as ClusterContext
+from .cluster import ClusterNode as ClusterNode
+from .cluster import ClusterStorage as ClusterStorage
 from .config import ArcaneOsConfig as ArcaneOsConfig
 from .config import ArcaneOsConfigGroup as ArcaneOsConfigGroup
 from .delegate import Delegate as Delegate
@@ -27,6 +30,9 @@ __all__ = [
     "AddressConfig",
     "ArcaneCreatorConfig",
     "ArcaneOsConfig",
+    "ClusterContext",
+    "ClusterNode",
+    "ClusterStorage",
     "ArcaneOsConfigGroup",
     "Delegate",
     "DiscordNotification",

--- a/src/arcane_mage/models/cluster.py
+++ b/src/arcane_mage/models/cluster.py
@@ -1,0 +1,107 @@
+"""Cluster topology data models for Proxmox cluster-aware provisioning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ClusterNode:
+    """A single node in a Proxmox cluster."""
+
+    name: str
+    online: bool
+    local: bool  # is this the node we connected to
+
+
+@dataclass(frozen=True)
+class ClusterStorage:
+    """A storage backend visible to the cluster."""
+
+    name: str
+    shared: bool
+    content: str  # e.g. "images,iso,import"
+    nodes: list[str] | None = None  # None = available on all nodes
+
+
+@dataclass
+class ClusterContext:
+    """Read-only snapshot of cluster topology, built once during connection setup.
+
+    Standalone Proxmox servers produce ``is_cluster=False`` with safe defaults.
+    """
+
+    is_cluster: bool = False
+    cluster_name: str | None = None
+    has_quorum: bool = True
+    nodes: list[ClusterNode] = field(default_factory=list)
+    storage: list[ClusterStorage] = field(default_factory=list)
+
+    @classmethod
+    def from_api_responses(
+        cls,
+        status_payload: list[dict],
+        storage_payload: list[dict],
+    ) -> ClusterContext:
+        """Build from ``GET /cluster/status`` + ``GET /storage`` responses.
+
+        If no ``type=cluster`` entry is present in the status payload, this is
+        a standalone node and ``is_cluster`` will be ``False``.
+        """
+        cluster_item = next(
+            (item for item in status_payload if item.get("type") == "cluster"),
+            None,
+        )
+
+        if not cluster_item:
+            return cls(is_cluster=False, has_quorum=True)
+
+        nodes = [
+            ClusterNode(
+                name=item["name"],
+                online=bool(item.get("online", 0)),
+                local=bool(item.get("local", 0)),
+            )
+            for item in status_payload
+            if item.get("type") == "node"
+        ]
+
+        storage = [
+            ClusterStorage(
+                name=item["storage"],
+                shared=bool(item.get("shared", 0)),
+                content=item.get("content", ""),
+                nodes=item["nodes"].split(",") if item.get("nodes") else None,
+            )
+            for item in storage_payload
+        ]
+
+        return cls(
+            is_cluster=True,
+            cluster_name=cluster_item.get("name"),
+            has_quorum=bool(cluster_item.get("quorate", 0)),
+            nodes=nodes,
+            storage=storage,
+        )
+
+    def is_storage_shared(self, storage_name: str) -> bool:
+        """Return whether the named storage is shared across nodes."""
+        return any(s.shared for s in self.storage if s.name == storage_name)
+
+    def is_node_online(self, node_name: str) -> bool:
+        """Return whether the named node is online in the cluster."""
+        node = next((n for n in self.nodes if n.name == node_name), None)
+        return node.online if node else False
+
+    def storage_available_on(self, storage_name: str) -> list[str]:
+        """Return the list of online nodes where the named storage is accessible."""
+        store = next((s for s in self.storage if s.name == storage_name), None)
+        if not store:
+            return []
+
+        online_names = {n.name for n in self.nodes if n.online}
+
+        if store.nodes is None:
+            return sorted(online_names)
+
+        return sorted(set(store.nodes) & online_names)

--- a/src/arcane_mage/models/hypervisor.py
+++ b/src/arcane_mage/models/hypervisor.py
@@ -25,6 +25,7 @@ class HypervisorConfig:
     credential: str = Field(repr=False)
     keychain: bool = True
     name: str | None = None
+    force_standalone: bool = False
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, HypervisorConfig):

--- a/src/arcane_mage/provisioner.py
+++ b/src/arcane_mage/provisioner.py
@@ -14,6 +14,7 @@ import yaml
 from .fat_writer import FAT12Writer
 from .helpers import do_http
 from .models import ArcaneOsConfig, ArcaneOsConfigGroup, HypervisorConfig
+from .models.cluster import ClusterContext
 from .proxmox import ProxmoxApi
 
 log = logging.getLogger(__name__)
@@ -114,8 +115,9 @@ class HypervisorDiscovery:
 class Provisioner:
     """Orchestrates Proxmox VM provisioning for Fluxnodes."""
 
-    def __init__(self, api: ProxmoxApi) -> None:
+    def __init__(self, api: ProxmoxApi, cluster: ClusterContext | None = None) -> None:
         self.api = api
+        self.cluster = cluster
 
     @classmethod
     async def from_hypervisor_config(cls, config: HypervisorConfig) -> Self | None:
@@ -137,7 +139,34 @@ class Provisioner:
         if not api:
             return None
 
-        return cls(api)
+        cluster: ClusterContext | None = None
+        if not config.force_standalone:
+            status_res = await api.get_cluster_status()
+            storage_res = await api.get_storage_config()
+            if status_res and storage_res:
+                ctx = ClusterContext.from_api_responses(
+                    status_res.payload, storage_res.payload
+                )
+                if ctx.is_cluster:
+                    cluster = ctx
+
+        return cls(api, cluster=cluster)
+
+    async def detect_cluster(self) -> None:
+        """Detect cluster topology and set ``self.cluster``.
+
+        Called automatically by ``from_hypervisor_config()``. Call this
+        explicitly when constructing a ``Provisioner`` directly via
+        ``Provisioner(api)``.
+        """
+        status_res = await self.api.get_cluster_status()
+        storage_res = await self.api.get_storage_config()
+        if status_res and storage_res:
+            ctx = ClusterContext.from_api_responses(
+                status_res.payload, storage_res.payload
+            )
+            if ctx.is_cluster:
+                self.cluster = ctx
 
     async def discover_nodes(
         self, all_configs: ArcaneOsConfigGroup
@@ -157,7 +186,7 @@ class Provisioner:
         async def handle_node(node: dict) -> None:
             if name := node.get("node"):
                 vm_res = await self.api.get_vms(name)
-                provisioned[name] = vm_res.payload
+                provisioned[name] = vm_res.payload or []
                 useable_nodes.add_nodes(all_configs.get_nodes_by_hypervisor_name(name))
 
         await asyncio.gather(*(handle_node(n) for n in hyper_nodes.payload))
@@ -547,6 +576,7 @@ class Provisioner:
         fluxnode: ArcaneOsConfig,
         callback: Callable[[bool, str], None] | None = None,
         delete_efi: bool = True,
+        skip_efi_upload: bool = False,
     ) -> bool:
         """Provision a single Fluxnode VM on a Proxmox hypervisor.
 
@@ -571,6 +601,31 @@ class Provisioner:
         if hv.node_tier not in TIER_CONFIG:
             _cb(False, f"Node tier: {hv.node_tier} does not exist")
             return False
+
+        if self.cluster:
+            if not self.cluster.has_quorum:
+                _cb(False, "Cluster has lost quorum, refusing to provision")
+                return False
+
+            if not self.cluster.is_node_online(hv.node):
+                _cb(False, f"Node '{hv.node}' is offline in cluster")
+                return False
+
+            resources_res = await self.api.get_cluster_resources(resource_type="vm")
+            if resources_res and isinstance(resources_res.payload, list):
+                duplicate = next(
+                    (r for r in resources_res.payload if r.get("name") == hv.vm_name),
+                    None,
+                )
+                if duplicate:
+                    existing_node = duplicate.get("node", "unknown")
+                    _cb(
+                        False,
+                        f"VM name '{hv.vm_name}' already exists on node '{existing_node}'",
+                    )
+                    return False
+
+            _cb(True, "Cluster pre-flight checks passed")
 
         version_valid, version_error = await self.validate_api_version(hv.node)
 
@@ -637,13 +692,16 @@ class Provisioner:
 
         _cb(True, "Config image uploaded")
 
-        efi_ok = await self.upload_arcane_efi(hv.node, hv.storage_import)
+        if skip_efi_upload:
+            _cb(True, "EFI image upload skipped (shared storage)")
+        else:
+            efi_ok = await self.upload_arcane_efi(hv.node, hv.storage_import)
 
-        if not efi_ok:
-            _cb(False, "Unable to upload EFI image to hypervisor")
-            return False
+            if not efi_ok:
+                _cb(False, "Unable to upload EFI image to hypervisor")
+                return False
 
-        _cb(True, "EFI image uploaded")
+            _cb(True, "EFI image uploaded")
 
         created_ok = await self.create_vm(vm_config, node=hv.node)
 

--- a/src/arcane_mage/proxmox.py
+++ b/src/arcane_mage/proxmox.py
@@ -300,6 +300,24 @@ class ProxmoxApi:
 
         return res
 
+    async def get_cluster_status(self) -> ApiResponse:
+        """GET /cluster/status — cluster name, quorum, node membership."""
+        res = await self._do_get("cluster/status")
+
+        return res
+
+    async def get_cluster_resources(
+        self, resource_type: str | None = None
+    ) -> ApiResponse:
+        """GET /cluster/resources — cluster-wide VM/storage/node list."""
+        path = "cluster/resources"
+        if resource_type:
+            path += f"?type={resource_type}"
+
+        res = await self._do_get(path)
+
+        return res
+
     async def get_hypervisor_nodes(self) -> ApiResponse:
         res = await self._do_get("nodes")
 

--- a/src/arcane_mage/proxmox.py
+++ b/src/arcane_mage/proxmox.py
@@ -394,6 +394,15 @@ class ProxmoxApi:
         return res
 
     async def get_task(self, task_id: str, node: str) -> ApiResponse:
+        # UPID format: "UPID:<node>:<pid>:<pstart>:<starttime>:<type>:<id>:<user>:"
+        # The task runs on whichever node's pveproxy accepted the request, which
+        # in cluster setups may differ from the caller's target node (e.g. uploads
+        # run on the connection node, not hv.node). Extract the real task node
+        # from the UPID so the status endpoint path matches.
+        upid_parts = task_id.split(":")
+        if len(upid_parts) >= 2 and upid_parts[0] == "UPID" and upid_parts[1]:
+            node = upid_parts[1]
+
         quoted_task = urllib.parse.quote(task_id)
         endpoint = f"nodes/{node}/tasks/{quoted_task}/status"
 

--- a/src/arcane_mage/screens/provisioning_info.py
+++ b/src/arcane_mage/screens/provisioning_info.py
@@ -37,7 +37,7 @@ class ProvisioningInfoScreen(ModalScreen):
         error_label = Label("", id="error-label")
         error_label.visible = False
         main_container = Container()
-        main_container.border_title = f"Provisioining: {self.vm_name}"
+        main_container.border_title = f"Provisioning: {self.vm_name}"
 
         wait_container = Horizontal(id="wait-container")
         wait_container.visible = False

--- a/src/arcane_mage/screens/welcome_proxmox.py
+++ b/src/arcane_mage/screens/welcome_proxmox.py
@@ -110,6 +110,24 @@ class WelcomeScreenProxmox(Screen):
 
         self.provisioner = provisioner
 
+        # Update cluster info display
+        cluster_label = self.query_one("#cluster-info", Label)
+        if provisioner.cluster:
+            c = provisioner.cluster
+            quorum_str = "ok" if c.has_quorum else "LOST"
+            node_count = len(c.nodes)
+            cluster_label.update(
+                f"Cluster: {c.cluster_name} | Nodes: {node_count} | Quorum: {quorum_str}"
+            )
+            cluster_label.display = True
+
+            if not c.has_quorum:
+                self.notify("Cluster has lost quorum — provisioning disabled", severity="warning")
+                sync_btn = self.query_one("#sync-all", Button)
+                sync_btn.disabled = True
+        else:
+            cluster_label.display = False
+
         discovery = await provisioner.discover_nodes(self.fluxnodes)
 
         if not discovery:
@@ -133,6 +151,7 @@ class WelcomeScreenProxmox(Screen):
             {"label": "Tier", "key": "tier"},
             {"label": "Network", "key": "network"},
             {"label": "Address", "key": "address"},
+            {"label": "Status", "key": "status"},
             {"label": "Provisioned", "key": "provisioned"},
         ]
 
@@ -140,11 +159,13 @@ class WelcomeScreenProxmox(Screen):
         for column in columns:
             table.add_column(**column)
 
+        cluster = getattr(self, "provisioner", None) and self.provisioner.cluster
+
         for fluxnode in fluxnodes:
             hyper = fluxnode.hypervisor
             row_key = f"{hyper.node}:{hyper.vm_name}"
 
-            hypervisor_nodes = provisioned_nodes.get(hyper.node, [])
+            hypervisor_nodes = provisioned_nodes.get(hyper.node) or []
 
             is_provisioned = bool(
                 next(
@@ -155,7 +176,12 @@ class WelcomeScreenProxmox(Screen):
                     None,
                 )
             )
-            table.add_row(*fluxnode.as_row(), is_provisioned, key=row_key)
+
+            node_status = ""
+            if cluster:
+                node_status = "online" if cluster.is_node_online(hyper.node) else "offline"
+
+            table.add_row(*fluxnode.as_row(), node_status, is_provisioned, key=row_key)
 
     def compose(self) -> ComposeResult:
         first_time_dialog = Label(
@@ -188,6 +214,9 @@ class WelcomeScreenProxmox(Screen):
                     )
                     yield Button("X", id="exit", classes="icon-button", tooltip="Exit")
             yield Rule()
+            cluster_info = Label("", id="cluster-info")
+            cluster_info.display = False
+            yield cluster_info
             with Vertical():
                 yield first_time_dialog
                 with Vertical(id="dt-container"):
@@ -294,8 +323,11 @@ class WelcomeScreenProxmox(Screen):
         fluxnode: ArcaneOsConfig,
         callback: Callable[[bool, str], None],
         delete_efi: bool = True,
+        skip_efi_upload: bool = False,
     ) -> bool:
-        result = await self.provisioner.provision_node(fluxnode, callback, delete_efi)
+        result = await self.provisioner.provision_node(
+            fluxnode, callback, delete_efi, skip_efi_upload=skip_efi_upload
+        )
 
         # Update UI after successful provisioning
         if result and fluxnode.hypervisor:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from arcane_mage.batch import BatchProvisioner, BatchResult, NodePlan
+from arcane_mage.models import ArcaneOsConfig
+from arcane_mage.models.cluster import ClusterContext, ClusterNode, ClusterStorage
+
+
+def _make_node(node_name: str, vm_name: str, storage_import: str = "local") -> ArcaneOsConfig:
+    """Build a minimal ArcaneOsConfig with just enough hypervisor info for planning."""
+    return ArcaneOsConfig.from_dict({
+        "fluxnode": {
+            "identity": {
+                "flux_id": "122Q5f5dJdiaoNP7iLbBgEt5fVF3g3DDeA",
+                "identity_key": "L4yreKb7oFfok5i38Zi5DZo7vA7wdjrGhs8gdPqNNxdsuNBaywcR",
+                "tx_id": "657e17cd88d2e7993b62dfc957baedf7b026b0ae31083d30eb7c8851a2dd91ba",
+                "output_id": 0,
+            },
+        },
+        "system": {"hostname": vm_name, "hashed_console": "!"},
+        "hypervisor": {
+            "node": node_name,
+            "vm_name": vm_name,
+            "node_tier": "cumulus",
+            "network": "vmbr0",
+            "iso_name": "FluxLive-1749291196.iso",
+            "storage_import": storage_import,
+        },
+    })
+
+
+def _make_cluster_context(shared_storages: list[str] | None = None) -> ClusterContext:
+    """Build a ClusterContext with configurable shared storage names."""
+    shared = set(shared_storages or [])
+    return ClusterContext(
+        is_cluster=True,
+        cluster_name="test",
+        has_quorum=True,
+        nodes=[
+            ClusterNode("pve1", online=True, local=True),
+            ClusterNode("pve2", online=True, local=False),
+        ],
+        storage=[
+            ClusterStorage("local", shared=False, content="images,import"),
+            *(
+                ClusterStorage(name, shared=True, content="images,import")
+                for name in shared
+            ),
+        ],
+    )
+
+
+class TestBuildPlan:
+    def test_single_node(self):
+        batch = BatchProvisioner(MagicMock(), cluster=None)
+        nodes = [_make_node("pve1", "vm1")]
+        plan = batch._build_plan(nodes)
+
+        assert len(plan) == 1
+        assert plan[0].skip_efi_upload is False
+        assert plan[0].delete_efi is True
+
+    def test_local_storage_no_cluster(self):
+        batch = BatchProvisioner(MagicMock(), cluster=None)
+        nodes = [
+            _make_node("pve1", "vm1"),
+            _make_node("pve1", "vm2"),
+            _make_node("pve1", "vm3"),
+        ]
+        plan = batch._build_plan(nodes)
+
+        # All upload, only last deletes
+        assert plan[0].skip_efi_upload is False
+        assert plan[0].delete_efi is False
+        assert plan[1].skip_efi_upload is False
+        assert plan[1].delete_efi is False
+        assert plan[2].skip_efi_upload is False
+        assert plan[2].delete_efi is True
+
+    def test_shared_storage_upload_once(self):
+        cluster = _make_cluster_context(shared_storages=["ceph"])
+        batch = BatchProvisioner(MagicMock(), cluster=cluster)
+        nodes = [
+            _make_node("pve1", "vm1", storage_import="ceph"),
+            _make_node("pve1", "vm2", storage_import="ceph"),
+            _make_node("pve1", "vm3", storage_import="ceph"),
+        ]
+        plan = batch._build_plan(nodes)
+
+        # First uploads, middle and last skip
+        assert plan[0].skip_efi_upload is False
+        assert plan[0].delete_efi is False
+        assert plan[1].skip_efi_upload is True
+        assert plan[1].delete_efi is False
+        assert plan[2].skip_efi_upload is True
+        assert plan[2].delete_efi is True
+
+    def test_mixed_shared_and_local_groups(self):
+        cluster = _make_cluster_context(shared_storages=["ceph"])
+        batch = BatchProvisioner(MagicMock(), cluster=cluster)
+        nodes = [
+            _make_node("pve1", "vm1", storage_import="ceph"),
+            _make_node("pve1", "vm2", storage_import="ceph"),
+            _make_node("pve2", "vm3", storage_import="local"),
+            _make_node("pve2", "vm4", storage_import="local"),
+        ]
+        plan = batch._build_plan(nodes)
+
+        # ceph group: first uploads, second skips + deletes
+        assert plan[0].skip_efi_upload is False
+        assert plan[0].delete_efi is False
+        assert plan[1].skip_efi_upload is True
+        assert plan[1].delete_efi is True
+
+        # local group: both upload, only last deletes
+        assert plan[2].skip_efi_upload is False
+        assert plan[2].delete_efi is False
+        assert plan[3].skip_efi_upload is False
+        assert plan[3].delete_efi is True
+
+    def test_empty_nodes(self):
+        batch = BatchProvisioner(MagicMock(), cluster=None)
+        plan = batch._build_plan([])
+        assert plan == []
+
+
+class TestProvisionBatch:
+    @pytest.mark.asyncio
+    async def test_all_succeed(self):
+        provisioner = MagicMock()
+        provisioner.provision_node = AsyncMock(return_value=True)
+
+        batch = BatchProvisioner(provisioner, cluster=None)
+        nodes = [_make_node("pve1", "vm1"), _make_node("pve1", "vm2")]
+        results = await batch.provision_batch(nodes)
+
+        assert len(results) == 2
+        assert all(r.ok for r in results)
+        assert provisioner.provision_node.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_failure_does_not_short_circuit(self):
+        provisioner = MagicMock()
+        provisioner.provision_node = AsyncMock(side_effect=[False, True])
+
+        batch = BatchProvisioner(provisioner, cluster=None)
+        nodes = [_make_node("pve1", "vm1"), _make_node("pve1", "vm2")]
+        results = await batch.provision_batch(nodes)
+
+        assert len(results) == 2
+        assert results[0].ok is False
+        assert results[1].ok is True
+
+    @pytest.mark.asyncio
+    async def test_shared_storage_failure_recovery(self):
+        """If the first node (EFI uploader) fails, the next node should upload EFI."""
+        cluster = _make_cluster_context(shared_storages=["ceph"])
+        provisioner = MagicMock()
+        provisioner.provision_node = AsyncMock(side_effect=[False, True])
+
+        batch = BatchProvisioner(provisioner, cluster=cluster)
+        nodes = [
+            _make_node("pve1", "vm1", storage_import="ceph"),
+            _make_node("pve1", "vm2", storage_import="ceph"),
+        ]
+        results = await batch.provision_batch(nodes)
+
+        # Second call should NOT have skip_efi_upload=True since first failed
+        second_call = provisioner.provision_node.call_args_list[1]
+        assert second_call.kwargs.get("skip_efi_upload") is False
+
+    @pytest.mark.asyncio
+    async def test_callback_receives_fluxnode(self):
+        provisioner = MagicMock()
+        provisioner.provision_node = AsyncMock(return_value=True)
+
+        batch = BatchProvisioner(provisioner, cluster=None)
+        nodes = [_make_node("pve1", "vm1")]
+
+        received = []
+
+        def cb(fluxnode, ok, msg):
+            received.append((fluxnode.system.hostname, ok, msg))
+
+        # The callback is called by provision_node's callback param,
+        # but since we mock provision_node, it won't actually call our cb.
+        # Instead verify that a callback was passed to provision_node.
+        await batch.provision_batch(nodes, callback=cb)
+
+        call_kwargs = provisioner.provision_node.call_args_list[0].kwargs
+        assert "callback" in call_kwargs
+        assert callable(call_kwargs["callback"])

--- a/tests/test_models/test_cluster.py
+++ b/tests/test_models/test_cluster.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from arcane_mage.models.cluster import ClusterContext, ClusterNode, ClusterStorage
+
+
+class TestClusterContextFromApiResponses:
+    def test_standalone_no_cluster_entry(self):
+        status = [{"type": "node", "name": "pve1", "online": 1, "local": 1}]
+        storage = [{"storage": "local", "shared": 0, "content": "images"}]
+
+        ctx = ClusterContext.from_api_responses(status, storage)
+
+        assert ctx.is_cluster is False
+        assert ctx.has_quorum is True
+        assert ctx.nodes == []
+        assert ctx.storage == []
+
+    def test_cluster_with_quorum(self):
+        status = [
+            {"type": "cluster", "name": "moltentech", "quorate": 1, "version": 6},
+            {"type": "node", "name": "pve35", "online": 1, "local": 1},
+            {"type": "node", "name": "pve45", "online": 1, "local": 0},
+            {"type": "node", "name": "pve50", "online": 0, "local": 0},
+        ]
+        storage = [
+            {"storage": "local", "shared": 0, "content": "images"},
+            {"storage": "ceph-pool", "shared": 1, "content": "images,import"},
+            {"storage": "nfs-share", "shared": 1, "content": "iso", "nodes": "pve35,pve45"},
+        ]
+
+        ctx = ClusterContext.from_api_responses(status, storage)
+
+        assert ctx.is_cluster is True
+        assert ctx.cluster_name == "moltentech"
+        assert ctx.has_quorum is True
+        assert len(ctx.nodes) == 3
+        assert len(ctx.storage) == 3
+
+    def test_cluster_without_quorum(self):
+        status = [
+            {"type": "cluster", "name": "test", "quorate": 0},
+            {"type": "node", "name": "pve1", "online": 1, "local": 1},
+        ]
+        storage = []
+
+        ctx = ClusterContext.from_api_responses(status, storage)
+
+        assert ctx.is_cluster is True
+        assert ctx.has_quorum is False
+
+    def test_node_online_and_local_flags(self):
+        status = [
+            {"type": "cluster", "name": "test", "quorate": 1},
+            {"type": "node", "name": "local-node", "online": 1, "local": 1},
+            {"type": "node", "name": "remote-node", "online": 1, "local": 0},
+            {"type": "node", "name": "offline-node", "online": 0, "local": 0},
+        ]
+
+        ctx = ClusterContext.from_api_responses(status, [])
+
+        local = next(n for n in ctx.nodes if n.name == "local-node")
+        assert local.online is True
+        assert local.local is True
+
+        remote = next(n for n in ctx.nodes if n.name == "remote-node")
+        assert remote.online is True
+        assert remote.local is False
+
+        offline = next(n for n in ctx.nodes if n.name == "offline-node")
+        assert offline.online is False
+        assert offline.local is False
+
+    def test_storage_shared_flag(self):
+        storage = [
+            {"storage": "local-lvm", "shared": 0, "content": "images"},
+            {"storage": "ceph-rbd", "shared": 1, "content": "images,import"},
+        ]
+        status = [{"type": "cluster", "name": "test", "quorate": 1}]
+
+        ctx = ClusterContext.from_api_responses(status, storage)
+
+        local = next(s for s in ctx.storage if s.name == "local-lvm")
+        assert local.shared is False
+
+        ceph = next(s for s in ctx.storage if s.name == "ceph-rbd")
+        assert ceph.shared is True
+
+    def test_storage_nodes_restriction(self):
+        storage = [
+            {"storage": "nfs", "shared": 1, "content": "iso", "nodes": "pve1,pve2"},
+            {"storage": "ceph", "shared": 1, "content": "images"},
+        ]
+        status = [{"type": "cluster", "name": "test", "quorate": 1}]
+
+        ctx = ClusterContext.from_api_responses(status, storage)
+
+        nfs = next(s for s in ctx.storage if s.name == "nfs")
+        assert nfs.nodes == ["pve1", "pve2"]
+
+        ceph = next(s for s in ctx.storage if s.name == "ceph")
+        assert ceph.nodes is None
+
+
+class TestClusterContextHelpers:
+    def _make_context(self):
+        return ClusterContext(
+            is_cluster=True,
+            cluster_name="test",
+            has_quorum=True,
+            nodes=[
+                ClusterNode("pve1", online=True, local=True),
+                ClusterNode("pve2", online=True, local=False),
+                ClusterNode("pve3", online=False, local=False),
+            ],
+            storage=[
+                ClusterStorage("local", shared=False, content="images"),
+                ClusterStorage("ceph", shared=True, content="images,import"),
+                ClusterStorage("nfs", shared=True, content="iso", nodes=["pve1", "pve2"]),
+            ],
+        )
+
+    def test_is_storage_shared(self):
+        ctx = self._make_context()
+        assert ctx.is_storage_shared("ceph") is True
+        assert ctx.is_storage_shared("local") is False
+        assert ctx.is_storage_shared("nonexistent") is False
+
+    def test_is_node_online(self):
+        ctx = self._make_context()
+        assert ctx.is_node_online("pve1") is True
+        assert ctx.is_node_online("pve2") is True
+        assert ctx.is_node_online("pve3") is False
+        assert ctx.is_node_online("unknown") is False
+
+    def test_storage_available_on_shared_all_nodes(self):
+        ctx = self._make_context()
+        # ceph has no node restriction, so available on all online nodes
+        available = ctx.storage_available_on("ceph")
+        assert available == ["pve1", "pve2"]
+
+    def test_storage_available_on_restricted(self):
+        ctx = self._make_context()
+        # nfs restricted to pve1, pve2 — both online
+        available = ctx.storage_available_on("nfs")
+        assert available == ["pve1", "pve2"]
+
+    def test_storage_available_on_local(self):
+        ctx = self._make_context()
+        # local has no node restriction, available on all online nodes
+        available = ctx.storage_available_on("local")
+        assert available == ["pve1", "pve2"]
+
+    def test_storage_available_on_nonexistent(self):
+        ctx = self._make_context()
+        assert ctx.storage_available_on("missing") == []
+
+    def test_storage_available_on_respects_offline(self):
+        ctx = ClusterContext(
+            is_cluster=True,
+            cluster_name="test",
+            has_quorum=True,
+            nodes=[
+                ClusterNode("pve1", online=True, local=True),
+                ClusterNode("pve2", online=False, local=False),
+            ],
+            storage=[
+                ClusterStorage("nfs", shared=True, content="iso", nodes=["pve1", "pve2"]),
+            ],
+        )
+        # pve2 is offline, so only pve1
+        assert ctx.storage_available_on("nfs") == ["pve1"]

--- a/tests/test_provisioner.py
+++ b/tests/test_provisioner.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from arcane_mage.models import ArcaneOsConfigGroup
 from arcane_mage.provisioner import TIER_CONFIG, Provisioner, is_api_min_version
 from arcane_mage.proxmox import ApiResponse
 
@@ -286,3 +287,29 @@ class TestProvisionerValidation:
 
         assert result is False
         assert any("not found" in msg for _, msg in messages)
+
+    async def test_discover_nodes_offline_node_returns_empty_list(
+        self, provisioner: Provisioner, mock_api: AsyncMock
+    ):
+        """Offline cluster nodes return payload=None from get_vms; discover_nodes
+        must coerce that to [] so downstream callers can iterate safely.
+        Regression: bare None leaked through and crashed build_fluxnode_table."""
+        mock_api.get_hypervisor_nodes.return_value = ApiResponse(
+            status=200,
+            payload=[{"node": "online-node"}, {"node": "offline-node"}],
+        )
+
+        async def get_vms_side_effect(name: str) -> ApiResponse:
+            if name == "offline-node":
+                return ApiResponse(status=200, payload=None)
+            return ApiResponse(status=200, payload=[{"vmid": 100, "name": "vm1"}])
+
+        mock_api.get_vms.side_effect = get_vms_side_effect
+
+        discovery = await provisioner.discover_nodes(ArcaneOsConfigGroup())
+
+        assert discovery is not None
+        assert discovery.provisioned_vms["offline-node"] == []
+        assert discovery.provisioned_vms["online-node"] == [{"vmid": 100, "name": "vm1"}]
+        for vms in discovery.provisioned_vms.values():
+            assert vms is not None


### PR DESCRIPTION
## Summary
- Adds cluster-aware provisioning per `cluster-architecture.md`: `ClusterContext` topology model, `BatchProvisioner` for EFI upload dedup on shared storage, pre-flight checks (quorum, node online, cluster-wide VM name uniqueness), `force_standalone` escape hatch, and TUI/CLI surfacing of cluster state.
- Backwards compatible — standalone Proxmox servers behave identically. CLI JSON output shape unchanged (extra cluster step appears as one more entry under `steps`).

## Test plan
- [x] 212 unit tests pass (`.venv/bin/pytest tests/`) — includes new `test_discover_nodes_offline_node_returns_empty_list` regression test
- [x] Test 1 — Standalone hypervisor (pve40 pre-cluster): unchanged behavior
- [x] Test 2 — Cluster detection (pve55, moltentech 6-node cluster)
- [x] Test 3 — Offline node pre-flight check (pve65 powered off): fails cleanly at 0% with "Node 'pve65' is offline in cluster"
- [x] Test 4 — Quorum loss: powered off 4/6 moltentech nodes (`pvecm status` Quorate=No, 2/6 votes), `provision -H pve55` returned `{"ok":false}` with "Cluster has lost quorum, refusing to provision" on both entries; no VMs created; quorum restored cleanly after power-on
- [x] Test 5 — VM name uniqueness collision detected across cluster
- [x] Test 6 — Shared-storage EFI dedup via NFS: first VM uploads, second shows "EFI image upload skipped (shared storage)", import dir cleaned once
- [x] Test 7 — Local storage unchanged: each VM uploads/cleans EFI independently
- [x] Test 8 — `force_standalone: true` on cluster member skips cluster logic
- [x] Test 9 — CLI provision: all steps including new cluster pre-flight appear correctly
- [x] Test 9a — CLI `--json` shape preserved; Moltentech provisioner container parsers compatible
- [x] Test 10 — Single-node TUI provision regression
- [x] Test 12 — CLI deprovision via cluster connection (targets specific node)
- [x] Test 14, 15, 16 — TUI column alignment / label hide-show / auth failure
- [x] Test 17 — total_steps consistency across cluster/non-cluster paths
- [x] Test 18 — Moltentech provisioner container end-to-end: rebuilt image (submodule at cluster-architecture tip), container swapped in prod on pve55, two real provisions driven by the Moltentech admin flow — pve40 (standalone, MT-0034 → mt-184-c9): all 9 steps pass, no cluster pre-flight step (correct); pve50 (moltentech cluster, MT-0035 → mt-187-c2): 10/10 steps pass including "Cluster pre-flight checks passed", config+EFI uploads via shared NFS, VM disk on local-lvm per slot config, JSON shape unchanged for index.js parser
- [ ] Test 13 — Ansible module regression: needs testing (not exercised in this verification pass)
- N/A — Test 11 (TUI deprovision, no such feature on master either)

## Notes
Contains fixes uncovered during manual testing:
- `discover_nodes()` coerces offline-node `None` payloads to `[]` (with regression test)
- CLI provision summary lines now self-describe (`{hostname}: Provisioned successfully`) instead of stacking under the last fluxnode block
- "Provisioining" → "Provisioning" typo in TUI progress dialog
- **`get_task()` UPID parsing for cross-node uploads in cluster mode** (commit f740763): multipart upload endpoints (`POST /nodes/<target>/storage/<s>/upload`) run the task on the connection node's pveproxy, not on `<target>` — the returned UPID encodes the real executing node. Previously `get_task()` built the status path using the caller-supplied node, producing a 400 mismatch and spurious "Unable to upload Config image" failures. Now the UPID prefix overrides the node so `wait_for_task()` polls `/nodes/<exec_node>/tasks/...` correctly. Only manifests when the provisioner can't reach the target node directly (e.g., behind a single cluster-API entry point) and shared storage is used for `storage_import`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)